### PR TITLE
Fix OWASP Juice Shop link and add crAPI resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Paid tranining courses
 
 ## OWASP Top 10
 
-- [Owasp Juice shop](https://github.com/bkimminich/juice-shop) - OWASP Juice Shop: Probably the most modern and sophisticated insecure web application
+- [Owasp Juice shop](https://github.com/juice-shop/juice-shop) - OWASP Juice Shop: Probably the most modern and sophisticated insecure web application
+- [crApi](https://github.com/OWASP/crAPI) - completely ridiculous API: crAPI will help you to understand the ten most critical API security risks. crAPI is vulnerable by design, but you'll be able to safely run it to educate/train yourself.
 - [DVWA](https://github.com/ethicalhack3r/DVWA) - Damn Vulnerable Web Application (DVWA)
 - [DSVW](https://github.com/stamparm/DSVW) - Damn Small Vulnerable Web
 - [bWAPP](https://github.com/raesene/bWAPP) - This is just an instance of the OWASP bWAPP project as a docker container.


### PR DESCRIPTION
Updated the link for OWASP Juice Shop and added crAPI to the list of resources.

# Description

Please explain the changes you made here:

- Fix OWASP Juice Shop link and add crAPI resource

## Notes

Please add screenshots or some additional context if you believe it is needed.

## Checklist

- [x] The application is **open-source** (preferred)
- [x] No **duplicate links** are added
- [x] The application is listed under the **correct category**
- [x] The application is **intentionally vulnerable** or suitable for security practice
- [x] Paid or online-only applications are included **only if justified and reviewed**
